### PR TITLE
Fix Grammar

### DIFF
--- a/lua/autorun/server/sv_RoleVote.lua
+++ b/lua/autorun/server/sv_RoleVote.lua
@@ -3,7 +3,7 @@ local voteban = GetConVar("ttt_rolevote_voteban"):GetBool()
 local minPlayers = GetConVar("ttt_rolevote_min_players"):GetInt()
 local count = GetConVar("ttt_rolevote_count"):GetInt()
 local role_cooldown = GetConVar("ttt_rolevote_role_cooldown"):GetInt()
-local always_active = string.Split(GetConVar("ttt_rolevote_always_aktiv"):GetString(), ",")
+local always_active = string.Split(GetConVar("ttt_rolevote_always_active"):GetString(), ",")
 
 for key, role in pairs(always_active) do
     always_active[key] = string.Trim(role)
@@ -171,12 +171,12 @@ net.Receive("RoleVote_vote", function(len, ply)
 end)
 
 concommand.Add("printRoles", function(ply)
-    local function addRoles(aktive, tbl)
+    local function addRoles(active, tbl)
         tbl = tbl or {}
         local i = 0
 
         for _, role in pairs(GetRoles()) do
-            if aktive and role:IsSelectable(false) or not aktive and not role:IsSelectable(false) and not role.notSelectable then
+            if active and role:IsSelectable(false) or not active and not role:IsSelectable(false) and not role.notSelectable then
                 i = i + 1
                 table.insert(tbl, role.color)
                 table.insert(tbl, string.SetChar(role.name, 1, string.upper(role.name[1])) .. " \t")
@@ -219,7 +219,7 @@ concommand.Add("printRoles", function(ply)
     end
 
     table.insert(msg, Color(255, 255, 255))
-    table.insert(msg, "Aktive Roles: \n")
+    table.insert(msg, "Active Roles: \n")
     addRoles(true, msg)
 
     if addRoles(false) > 0 then

--- a/lua/autorun/sh_RoleVote_cvars.lua
+++ b/lua/autorun/sh_RoleVote_cvars.lua
@@ -3,7 +3,7 @@ CreateConVar("ttt_rolevote_voteban", 1, {FCVAR_ARCHIVE, FCVAR_NOTIFY}, "0: The p
 CreateConVar("ttt_rolevote_min_players", 7, {FCVAR_ARCHIVE, FCVAR_NOTIFY}, "Sets the minimum players that have to be online for RoleVote being active", 1):GetInt()
 CreateConVar("ttt_rolevote_count", 1, {FCVAR_ARCHIVE, FCVAR_NOTIFY}, "Sets how many roles will be banned/activated", 1):GetInt()
 CreateConVar("ttt_rolevote_role_cooldown", 1, {FCVAR_ARCHIVE, FCVAR_NOTIFY}, "Sets how many times a role can't be voted on after it has won a vote.", 0):GetInt()
-CreateConVar("ttt_rolevote_always_aktiv", "", {FCVAR_ARCHIVE, FCVAR_NOTIFY}, "Always activated roles (separated by ,)"):GetString()
+CreateConVar("ttt_rolevote_always_active", "", {FCVAR_ARCHIVE, FCVAR_NOTIFY}, "Always activated roles (separated by ,)"):GetString()
 
 hook.Add("TTTUlxInitCustomCVar", "TTTRolevoteInitRWCVar", function(name)
     ULib.replicatedWritableCvar("ttt_rolevote_enabled", "rep_ttt_rolevote_enabled", GetConVar("ttt_rolevote_enabled"):GetBool(), true, false, name)
@@ -11,7 +11,7 @@ hook.Add("TTTUlxInitCustomCVar", "TTTRolevoteInitRWCVar", function(name)
     ULib.replicatedWritableCvar("ttt_rolevote_min_players", "rep_ttt_rolevote_min_players", GetConVar("ttt_rolevote_min_players"):GetInt(), true, false, name)
     ULib.replicatedWritableCvar("ttt_rolevote_count", "rep_ttt_rolevote_count", GetConVar("ttt_rolevote_count"):GetInt(), true, false, name)
     ULib.replicatedWritableCvar("ttt_rolevote_role_cooldown", "rep_ttt_rolevote_role_cooldown", GetConVar("ttt_rolevote_role_cooldown"):GetInt(), true, false, name)
-    ULib.replicatedWritableCvar("ttt_rolevote_always_aktiv", "rep_ttt_rolevote_always_aktiv", GetConVar("ttt_rolevote_always_aktiv"):GetString(), true, false, name)
+    ULib.replicatedWritableCvar("ttt_rolevote_always_active", "rep_ttt_rolevote_always_active", GetConVar("ttt_rolevote_always_active"):GetString(), true, false, name)
 end)
 
 if SERVER then


### PR DESCRIPTION
the word "aktive" does not exist in english. If it would, it would also mean deaktivated or aktivate and that is a no go.